### PR TITLE
Update bindir in rubocop-diff.gemspec

### DIFF
--- a/rubocop-diff.gemspec
+++ b/rubocop-diff.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |spec|
   spec.license       = 'MIT'
 
   spec.files         = `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
-  spec.bindir        = 'exe'
+  spec.bindir        = 'bin'
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 


### PR DESCRIPTION
Bug introduced by 8447aa63761c502efe429651747d484c18411501